### PR TITLE
Update config to allow binding to a host

### DIFF
--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -1,6 +1,7 @@
 # The port to listen to for HTTP requests
 server:
     port: 9000
+    host: "::1"
 
 scan:
     # The script that will be given a file as it's first parameter

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,7 @@ const Joi = require('joi');
 const configSchema = Joi.object().keys({
     server: Joi.object().keys({
         port: Joi.number().required(),
+	host: Joi.string().required(),
     }).required(),
     scan: Joi.object().keys({
         script: Joi.string().required(),

--- a/src/index.js
+++ b/src/index.js
@@ -82,4 +82,4 @@ attachHandlers(app);
 // any ClientErrors that are thrown by the handlers.
 app.use(errorMiddleware);
 
-app.listen(serverConfig.port, () => console.log('Listening on ' + serverConfig.port));
+app.listen(serverConfig.port, serverConfig.host, () => console.log('Listening on ' +serverConfig.host + ":" + serverConfig.port));


### PR DESCRIPTION
These changes will allow us to specify the host to listen on - so we don't bind to public IPs without explicit configuration to do so.

I couldn't see a "IP" in the Joi documentation, so going with string (and assuming there'll be a failure if we cannot bind to it).

Tested in a vagrant container and verified by netstat:
```
tcp        0      0 127.0.0.1:9000          0.0.0.0:*               LISTEN      -
```

New log line looks like so:
```
Jun 06 09:41:36 jessie npm[5734]: Listening on 127.0.0.1:9000
```