### PR TITLE
Scan de-duplication & simpler file clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "joi": "^13.3.0",
     "js-yaml": "^3.12.0",
     "request": "^2.87.0",
-    "request-promise": "^4.2.2"
+    "request-promise": "^4.2.2",
+    "rimraf": "^2.6.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -48,8 +48,30 @@ function clearReportCache() {
     resultCache = {};
 }
 
+const rimraf = require('rimraf');
+function withTempDir(asyncFn) {
+    return async (...args) => {
+        const opts = args[args.length - 1];
+        const { tempDirectory } = opts;
+
+        const tempDir = await fs.promises.mkdtemp(`${tempDirectory}${path.sep}av-`);
+
+        // Copy all options, overide tempDir
+        args[args.length - 1] = Object.assign({}, opts, {tempDirectory: tempDir});
+
+        let result;
+        try {
+            result = await asyncFn(...args);
+        } finally {
+            await new Promise((resolve, reject) => rimraf(tempDir, (err) => err ? reject(err) : resolve()));
+        }
+
+        return result;
+    }
+}
+
 // Get cached report for the given URL
-async function getReport(console, domain, mediaId, eventContentFile, opts) {
+const getReport = withTempDir(async function(console, domain, mediaId, eventContentFile, opts) {
     const { baseUrl } = opts;
 
     if (eventContentFile) {
@@ -65,31 +87,31 @@ async function getReport(console, domain, mediaId, eventContentFile, opts) {
     console.info(`Returning scan report: domain = ${domain}, mediaId = ${mediaId}, clean = ${clean}`);
 
     return { clean, scanned: true, info };
-}
+});
 
-async function scannedDownload(req, res, domain, mediaId, eventContentFile, opts) {
-    opts.withCleanFile = function(filePath, headers, fn) {
-        req.console.info(`Sending ${filePath} to client`);
-
-        const responseHeaders = {};
-        const headerWhitelist = [
-            'content-type',
-            'content-disposition',
-            'content-security-policy',
-        ];
-        // Copy headers from media download to response
-        headerWhitelist.forEach((headerKey) => responseHeaders[headerKey] = headers[headerKey]);
-
-        res.set(responseHeaders);
-        res.sendFile(filePath, fn);
-    };
-
-    const { clean, info } = await generateReport(req.console, domain, mediaId, eventContentFile, opts);
+const scannedDownload = withTempDir(async function (req, res, domain, mediaId, eventContentFile, opts) {
+    const {
+        clean, info, filePath, headers
+    } = await generateReport(req.console, domain, mediaId, eventContentFile, opts);
 
     if (!clean) {
         throw new ClientError(403, info);
     }
-}
+
+    req.console.info(`Sending ${filePath} to client`);
+
+    const responseHeaders = {};
+    const headerWhitelist = [
+        'content-type',
+        'content-disposition',
+        'content-security-policy',
+    ];
+    // Copy headers from media download to response
+    headerWhitelist.forEach((headerKey) => responseHeaders[headerKey] = headers[headerKey]);
+
+    res.set(responseHeaders);
+    res.sendFile(filePath);
+});
 
 function getResultSecret(_, domain, mediaId, eventContentFile, opts) {
     if (eventContentFile) {
@@ -123,6 +145,8 @@ async function _generateReport(console, domain, mediaId, eventContentFile, opts)
         throw new Error('Expected baseUrl, tempDirectory and script in opts');
     }
 
+    const tempDir = tempDirectory;
+
     if (eventContentFile) {
         [domain, mediaId] = eventContentFile.url.split('/').slice(-2);
     }
@@ -131,14 +155,7 @@ async function _generateReport(console, domain, mediaId, eventContentFile, opts)
 
     const resultSecret = generateResultHash(httpUrl, eventContentFile);
 
-    const tempDir = await fs.promises.mkdtemp(`${tempDirectory}${path.sep}av-`);
     const filePath = path.join(tempDir, 'downloadedFile');
-
-    async function cleanUp() {
-        console.info(`Removing ${filePath} and ${tempDir}`);
-        await fs.promises.unlink(filePath);
-        await fs.promises.rmdir(tempDir);
-    }
 
     console.info(`Downloading ${httpUrl}, writing to ${filePath}`);
 
@@ -166,7 +183,6 @@ async function _generateReport(console, domain, mediaId, eventContentFile, opts)
 
         console.error(`Receieved status code ${err.statusCode} when requesting ${httpUrl}`);
 
-        await cleanUp();
         throw new ClientError(502, 'Failed to get requested URL');
     }
 
@@ -180,11 +196,8 @@ async function _generateReport(console, domain, mediaId, eventContentFile, opts)
 
     console.info(`Result: url = "${httpUrl}", clean = ${result.clean}, exit code = ${result.exitCode}`);
 
-    if (result.clean && opts.withCleanFile) {
-        opts.withCleanFile(filePath, downloadHeaders, cleanUp);
-    } else {
-        cleanUp();
-    }
+    result.filePath = filePath;
+    result.headers = downloadHeaders;
 
     return result;
 }
@@ -208,12 +221,6 @@ async function generateResult(console, eventContentFile, filePath, tempDir, scri
     const cmd = script + ' ' + decryptedFilePath;
     console.info(`Running command ${cmd}`);
     const result = await executeCommand(cmd);
-
-    // We don't need the decrypted data, so remove it.
-    if (filePath !== decryptedFilePath) {
-        console.info(`Removing ${decryptedFilePath}`);
-        await fs.promises.unlink(decryptedFilePath);
-    }
 
     return result;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,7 +317,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@7.1.2:
+glob@7.1.2, glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -655,6 +655,12 @@ request@^2.87.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
 
 safe-buffer@5.1.1:
   version "5.1.1"


### PR DESCRIPTION
I suspect @dbkr will have thoughts on the fact that `opts.tempDirectory` is operated on by `withTempDir`. Perhaps there's a better way to do this?

