### PR TITLE
Implement `directDownload` config option for downloading from media domain 

### DIFF
--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -10,3 +10,13 @@ scan:
     tempDirectory: '/tmp'
     # The base URL of the Home Server to download media from
     baseUrl: 'https://matrix.org'
+
+    # If set to true, effectively set baseUrl to
+    #   "https://$domain"
+    #   where $domain is the domain part of the requested media.
+    #
+    # This should only be used when it is preferable not to download
+    # media through the normal route: via a single (and federated)
+    # Home Server.
+    #
+    # directDownload: false

--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -8,7 +8,7 @@ scan:
     script: './example.sh'
     # The temporary directory to use
     tempDirectory: '/tmp'
-    # The base URL of the Home Server to download media from
+    # The base URL of the homeserver to download media from
     baseUrl: 'https://matrix.org'
 
     # If set to true, effectively set baseUrl to
@@ -17,6 +17,6 @@ scan:
     #
     # This should only be used when it is preferable not to download
     # media through the normal route: via a single (and federated)
-    # Home Server.
+    # homeserver.
     #
     # directDownload: false

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,7 @@ const configSchema = Joi.object().keys({
         script: Joi.string().required(),
         tempDirectory: Joi.string().required(),
         baseUrl: Joi.string().required(),
+        directDownload: Joi.boolean(),
     }).required(),
 });
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -89,13 +89,14 @@ async function downloadHandler(req, res, next, matrixFile, thumbnailQueryParams)
 
     const { domain, mediaId } = req.params;
 
-    const { script, tempDirectory, baseUrl } = config.scan;
+    const { script, tempDirectory, baseUrl, directDownload } = config.scan;
     const opts = {
         script,
         tempDirectory,
         baseUrl,
 
         thumbnailQueryParams,
+        directDownload,
     };
 
     const cachedReport = await getReport(req.console, domain, mediaId, matrixFile, opts);
@@ -108,13 +109,14 @@ async function downloadHandler(req, res, next, matrixFile, thumbnailQueryParams)
 }
 
 async function proxyDownload(req, res, domain, mediaId, matrixFile, thumbnailQueryParams, config) {
-    const { script, tempDirectory, baseUrl } = config;
+    const { script, tempDirectory, baseUrl, directDownload } = config;
     const opts = {
         script,
         tempDirectory,
         baseUrl,
 
         thumbnailQueryParams,
+        directDownload,
     };
 
     const {

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -70,6 +70,9 @@ function clearReportCache() {
  * @param {string} opts.thumbnailQueryParams If set, use as query parameters to request
  * a thumbnail. All thumbnail query parameters are optional, so passing `{ }` will download
  * a thumbnail without query parameters.
+ * @param {string} opts.directDownload If true, download media directly from the media's content
+ * repository. This should only be used if the `domain` is trusted for downloading media from
+ * directly.
  *
  * @returns {Promise} A promise that resolves with a report:
  * ```
@@ -139,6 +142,12 @@ const generateReportFromDownload = deduplicatePromises(getInputHash, _generateRe
  * @param {string} opts.baseUrl The URL of the homeserver to request media from.
  * @param {string} opts.tempDirectory The path to a directory where files can be written.
  * @param {string} opts.script The script to run against the downloaded file.
+ * @param {string} opts.thumbnailQueryParams If set, use as query parameters to request
+ * a thumbnail. All thumbnail query parameters are optional, so passing `{ }` will download
+ * a thumbnail without query parameters.
+ * @param {string} opts.directDownload If true, download media directly from the media's content
+ * repository. This should only be used if the `domain` is trusted for downloading media from
+ * directly.
  *
  * @returns {Promise} A promise that resolves with a report:
  * ```

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -43,8 +43,11 @@ function generateReportHash(httpUrl, matrixFile=undefined, thumbnailQueryParams=
 }
 
 // Transform MXC components into HTTP URL
-function generateHttpUrl(baseUrl, domain, mediaId, isThumbnail=false) {
+function generateHttpUrl(baseUrl, domain, mediaId, isThumbnail=false, directDownload=false) {
     const mediaType = isThumbnail ? 'thumbnail' : 'download';
+    if (directDownload) {
+        baseUrl = `https://${domain}`;
+    }
     return `${baseUrl}/_matrix/media/v1/${mediaType}/${domain}/${mediaId}`;
 }
 
@@ -74,13 +77,13 @@ function clearReportCache() {
  * ```
  **/
 const getReport = async function(console, domain, mediaId, matrixFile, opts) {
-    const { baseUrl, thumbnailQueryParams } = opts;
+    const { baseUrl, thumbnailQueryParams, directDownload } = opts;
 
     if (matrixFile) {
         [domain, mediaId] = matrixFile.url.split('/').slice(-2);
     }
 
-    const httpUrl = generateHttpUrl(baseUrl, domain, mediaId, Boolean(thumbnailQueryParams));
+    const httpUrl = generateHttpUrl(baseUrl, domain, mediaId, Boolean(thumbnailQueryParams), directDownload);
     const reportHash = generateReportHash(httpUrl, matrixFile, thumbnailQueryParams);
 
     if (!reportCache[reportHash]) {
@@ -152,7 +155,7 @@ const generateReportFromDownload = deduplicatePromises(getInputHash, _generateRe
  * ```
  **/
 async function _generateReportFromDownload(console, domain, mediaId, matrixFile, opts) {
-    const { baseUrl, tempDirectory, script, thumbnailQueryParams } = opts;
+    const { baseUrl, tempDirectory, script, thumbnailQueryParams, directDownload } = opts;
     if (baseUrl === undefined || tempDirectory === undefined || script === undefined) {
         throw new Error('Expected baseUrl, tempDirectory and script in opts');
     }
@@ -163,7 +166,9 @@ async function _generateReportFromDownload(console, domain, mediaId, matrixFile,
         [domain, mediaId] = matrixFile.url.split('/').slice(-2);
     }
 
-    const httpUrl = generateHttpUrl(baseUrl, domain, mediaId, Boolean(thumbnailQueryParams));
+    const httpUrl = generateHttpUrl(
+        baseUrl, domain, mediaId, Boolean(thumbnailQueryParams), directDownload,
+    );
 
     const filePath = path.join(tempDir, 'downloadedFile');
     const fileWriteStream = fs.createWriteStream(filePath);


### PR DESCRIPTION
This option effectively sets the `baseUrl` for a given request for media
with the domain replaced with the media's domain. This forces a direct
download from the media's content repo.

`baseUrl` is effectively unused with this option enabled, but this is
probably better than enabling `directDownload` when `baseUrl` is not
specified. The option should only be used in the minority of cases
where the content scanner has restricted access to a set of trusted
content repositories so as to prevent downloading and scanning of
content from *any* domain.