### PR TITLE
Implement config option to replace node's unlink function

### DIFF
--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -10,3 +10,10 @@ scan:
     tempDirectory: '/tmp'
     # The base URL of the Home Server to download media from
     baseUrl: 'https://matrix.org'
+
+# Optional. A command to execute when unlinking files from the file
+# system instead of using node's fs.unlink. When executed, the first
+# argument to the command will be the path of the file being
+# removed.
+#
+# altRemovalCmd: 'rm'

--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ const configSchema = Joi.object().keys({
         tempDirectory: Joi.string().required(),
         baseUrl: Joi.string().required(),
     }).required(),
+    altRemovalCmd: Joi.string(),
 });
 
 // Exported alongside mechanism to load particular configuarion

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const Joi = require('joi');
 const configSchema = Joi.object().keys({
     server: Joi.object().keys({
         port: Joi.number().required(),
-	host: Joi.string().required(),
+        host: Joi.string().required(),
     }).required(),
     scan: Joi.object().keys({
         script: Joi.string().required(),

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -16,6 +16,8 @@ limitations under the License.
 
 **/
 
+const child_process = require('child_process');
+
 const Joi = require('joi');
 const validate = require('express-validation');
 
@@ -29,6 +31,27 @@ function wrapAsyncHandle(fn) {
 }
 
 const { getConfig } = require('./config.js');
+
+/**
+ * Create a replacement function for `fs.unlink` that executes altRemovalCmd with
+ * the file path as the first argument.
+ */
+function getUnlinkFn(console) {
+    const alternateRemovalCommand = getConfig().altRemovalCmd;
+
+    let fn;
+    if (alternateRemovalCommand) {
+        fn = (path, errCallback) => {
+            const callback = (err) => {
+                if (err) errCallback(err);
+            }
+            child_process.execFile(alternateRemovalCommand, [path], callback);
+        }
+        console.info(`Will unlink file paths with alternate command "${alternateRemovalCommand}"`);
+    }
+
+    return fn;
+}
 
 const encryptedRequestSchema = {
     body: {
@@ -104,7 +127,8 @@ async function downloadHandler(req, res, next, matrixFile, thumbnailQueryParams)
         throw new ClientError(403, cachedReport.info);
     }
 
-    await withTempDir(tempDirectory, proxyDownload)(req, res, domain, mediaId, matrixFile, thumbnailQueryParams, config.scan);
+    const proxyDownloadWithTmpDir = withTempDir(tempDirectory, proxyDownload, getUnlinkFn(req.console));
+    await proxyDownloadWithTmpDir(req, res, domain, mediaId, matrixFile, thumbnailQueryParams, config.scan);
 }
 
 async function proxyDownload(req, res, domain, mediaId, matrixFile, thumbnailQueryParams, config) {
@@ -156,10 +180,14 @@ async function scanReportHandler(req, res, next, matrixFile) {
     let result = await getReport(req.console, domain, mediaId, matrixFile, config.scan);
 
     if (!result.scanned) {
-        result = await withTempDir(
+        const generateReportFromDownloadWithTmpDir = withTempDir(
             config.scan.tempDirectory,
-            generateReportFromDownload
-        )(req.console, domain, mediaId, matrixFile, config.scan);
+            generateReportFromDownload,
+            getUnlinkFn(req.console),
+        );
+        result = await generateReportFromDownloadWithTmpDir(
+            req.console, domain, mediaId, matrixFile, config.scan
+        );
     }
 
     const { clean, info } = result;


### PR DESCRIPTION
When temporary files are unlinked from the filesystem, execute
`altRemovalCmd` with the file as the first argument instead of using
node's unlink function.