### PR TITLE
Implement middleware to decipher encrypted POST requests

### DIFF
--- a/src/decrypt-body.js
+++ b/src/decrypt-body.js
@@ -1,0 +1,52 @@
+/**
+
+Copyright 2018 New Vector Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+**/
+
+const { PkDecryption } = require('olm');
+const ClientError = require('../src/client-error.js');
+
+const decryption = new PkDecryption();
+const publicKey = decryption.generate_key();
+
+function decryptBody(encryptedBody) {
+    const { ephemeral, mac, ciphertext } = encryptedBody;
+
+    let decrypted;
+    try {
+        decrypted = decryption.decrypt(ephemeral, mac, ciphertext);
+    } catch (err) {
+        throw new ClientError(403, `Bad decryption: ${err.message}`);
+    }
+
+    let result;
+    try {
+        result = JSON.parse(decrypted);
+    } catch (err) {
+        throw new ClientError(400, `Malformed JSON: ${err.message}`);
+    }
+
+    return result;
+}
+
+function getPublicKey() {
+    return publicKey;
+}
+
+module.exports = {
+    decryptBody,
+    getPublicKey,
+};

--- a/src/encrypted-body-middleware.js
+++ b/src/encrypted-body-middleware.js
@@ -1,0 +1,37 @@
+/**
+
+Copyright 2018 New Vector Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+**/
+
+const { decryptBody } = require('./decrypt-body.js');
+
+function encryptedBodyMiddleware(req, res, next) {
+    // If a POST body contains `encrypted_body`, decrypt it and pass it as a body
+    // to the next middleware
+
+    if (req.method === 'POST' && req.body && req.body.encrypted_body) {
+        try {
+            req.body = decryptBody(req.body.encrypted_body);
+        } catch (err) {
+            next(err);
+            return;
+        }
+    }
+
+    next();
+}
+
+module.exports = encryptedBodyMiddleware;

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -23,6 +23,7 @@ const validate = require('express-validation');
 
 const { getReport, generateReportFromDownload } = require('./reporting.js');
 const withTempDir = require('./with-temp-dir.js');
+const { getPublicKey } = require('./decrypt-body.js');
 
 const ClientError = require('./client-error.js');
 
@@ -199,6 +200,14 @@ async function scanReportHandler(req, res, next, matrixFile) {
     res.status(200).json(responseBody);
 }
 
+function publicKeyHandler(req, res, next) {
+    const responseBody = {
+        public_key: getPublicKey(),
+    };
+
+    res.status(200).json(responseBody);
+}
+
 function attachHandlers(app) {
     app.post(
         '/_matrix/media_proxy/unstable/download_encrypted',
@@ -225,6 +234,7 @@ function attachHandlers(app) {
         validate(unencryptedRequestSchema),
         wrapAsyncHandle(scanReportHandler)
     );
+    app.get('/_matrix/media_proxy/unstable/public_key', publicKeyHandler);
 }
 
 module.exports = {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 const express = require('express');
 const consoleMiddleware = require('./console-middleware.js');
+const encryptedBodyMiddleware = require('./encrypted-body-middleware.js');
 const ClientError = require('./client-error.js');
 
 function jsonErrorMiddleware(err, req, res, next) {
@@ -31,6 +32,10 @@ function attachMiddlewares(app) {
     // Add express-provided JSON but give it it's own unique error handling instead
     // of falling back on the generic one - handing these back to the client is OK.
     app.use(express.json(), jsonErrorMiddleware);
+
+    // Add middleware to replace requests with `encrypted_body` with the deciphered
+    // body.
+    app.use(encryptedBodyMiddleware);
 }
 
 module.exports = {

--- a/test/decrypt-body-test.js
+++ b/test/decrypt-body-test.js
@@ -1,0 +1,72 @@
+/**
+
+Copyright 2018 New Vector Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+**/
+
+const assert = require('assert');
+const { PkEncryption } = require('olm');
+const { decryptBody, getPublicKey } = require('../src/decrypt-body.js');
+const ClientError = require('../src/client-error.js');
+
+// In reality, getting the public key, and doing an encryption is done
+// client-side.
+const publicKey = getPublicKey();
+
+const encryption = new PkEncryption();
+encryption.set_recipient_key(getPublicKey());
+
+describe('decryptBody', () => {
+    it('should decrypt an encrypted body', async () => {
+        const plainBody = {
+            some: 'body',
+            with: 'keys',
+            nested: {
+                arbitrary: 'structure',
+            },
+        };
+        const encryptedBody = encryption.encrypt(JSON.stringify(plainBody));
+
+        const decryptedBody = decryptBody(encryptedBody);
+        assert.deepStrictEqual(decryptedBody, plainBody);
+    });
+
+    it('should throw 400 if the decrypted body is malformed', async () => {
+        const encryptedBody = encryption.encrypt('this is not JSON');
+
+        assert.throws(
+            () => decryptBody(encryptedBody),
+            (e) => e instanceof ClientError && e.status === 400,
+        );
+    });
+
+    it('should throw 403 if the decryption is bad', async () => {
+        const plainBody = {
+            some: 'body',
+            with: 'keys',
+            nested: {
+                arbitrary: 'structure',
+            },
+        };
+        const encryptedBody = encryption.encrypt(JSON.stringify(plainBody));
+
+        encryptedBody.mac = "this is not the mac";
+
+        assert.throws(
+            () => decryptBody(encryptedBody),
+            (e) => e instanceof ClientError && e.status === 403,
+        );
+    });
+});


### PR DESCRIPTION
Add a generic middleware for POST endpoints that allows them to
accept requests that contain enciphered JSON strings.

The request body has the following structure:

```json
{
    "ephemeral": "[base64-encoded ephemeral public key]",
    "mac": "[base64-encodeed MAC]",
    "ciphertext": "[base64-encoded ciphertext of the JSON body]"
}
```

The above can be calculated with matrix-olm `PkEncryption`. The
public key of the server is required to do this and can be found
by doing a GET request to the `.../media_proxy/unstable/public_key`
endpoint.