### PR TITLE
Bugfix for hanging scan when using altRemovalCmd

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -42,10 +42,7 @@ function getUnlinkFn(console) {
 
     let fn;
     if (alternateRemovalCommand) {
-        fn = (path, errCallback) => {
-            const callback = (err) => {
-                if (err) errCallback(err);
-            }
+        fn = (path, callback) => {
             child_process.execFile(alternateRemovalCommand, [path], callback);
         }
         console.info(`Will unlink file paths with alternate command "${alternateRemovalCommand}"`);

--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -33,7 +33,8 @@ setConfig({
         baseUrl: "https://matrix.org",
         tempDirectory: "/tmp",
         script: "exit 0"
-    }
+    },
+    altRemovalCmd: 'rm'
 });
 
 // XXX: These tests still don't make use of example.file.data


### PR DESCRIPTION
If merged, my `npm test` fails with a timeout.