### PR TITLE
Add reasons to client errors for disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ HTTP/1.1 200 OK
 ```
 
 # Error Codes
+Client errors are exposed as JSON responses with HTTP error codes that are not 200. An error response might look like this:
+```http
+HTTP/1.1 403 Forbidden
+...
+{
+  "info": "***VIRUS DETECTED***",
+  "reason": "MCS_MEDIA_NOT_CLEAN"
+}
+```
+
+## Documented Error Codes
 
 Status Code | Reason | Description
 ------------|--------|------------

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Request body fields:
  - `file.url`: The MXC URL of the file to fetch from the HS.
  - `file.key`, `file.iv`, `file.hashes` and `file.key`: encryption data required to decrypt the media once downloaded.
 
-#### Example Encrypted Request
+# Encrypted POST API
 The request body of any POST request can be encrypted using the public key exposed by `.../public_key`. This can be done by using the `PkEncryption` class from of the [Olm](https://git.matrix.org/git/olm) library.
 
 ```http
@@ -155,10 +155,11 @@ Request body fields:
  - `encrypted_body.mac`: The base64-encoded string representing the MAC.
  - `encrypted_body.ephemeral`: The base64-encoded string representing the ephemeral public key.
 
+## `403 { ..., reason: 'MCS_BAD_DECRYPTION' }`
+This response indicates that the client should request the public key of the server again and retry the request a single time.
+
 ### `GET .../public_key`
 Returns the current public curve25519 key of server. This can be used to encrypt `encrypted_body` requests.
-
-(TODO: indicate outdated public key with 403 JSON response when using `encrypted_body`.)
 
 #### Example Response
 ```http

--- a/README.md
+++ b/README.md
@@ -168,3 +168,14 @@ HTTP/1.1 200 OK
   "public_key": "[base64-encoded curve25519 public key of the server]"
 }
 ```
+
+# Error Codes
+
+Status Code | Reason | Description
+------------|--------|------------
+502 | `MCS_MEDIA_REQUEST_FAILED` | The server failed to request media from the media repo.
+400 | `MCS_MEDIA_FAILED_TO_DECRYPT` | The server failed to decrypt the encrypted media downloaded from the media repo.
+403 | `MCS_MEDIA_NOT_CLEAN` | The server scanned the downloaded media but the antivirus script returned a non-zero exit code.
+403 | `MCS_BAD_DECRYPTION` | The provided `encrypted_body` could not be decrypted. The client should request the public key of the server and then retry (once).
+400 | `MCS_MALFORMED_JSON` | The request body contains malformed JSON.
+500 | - | The server experienced an unexpected error.

--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,7 @@ limitations under the License.
 const express = require('express');
 
 const ClientError = require('./client-error.js');
-const { attachMiddlewares } = require('./middlewares.js');
+const { attachMiddlewares, attachErrorMiddlewares } = require('./middlewares.js');
 const { attachHandlers } = require('./handlers.js');
 
 const { loadConfig, getConfig } = require('./config.js');
@@ -27,45 +27,13 @@ const { loadConfig, getConfig } = require('./config.js');
 const process = require('process');
 const path = require('path');
 
-function respondWithError(req, res, err) {
-    req.console.info(`Responding to client with error: ${err.status} ${err.message}`);
-    res.status(err.status).json({
-        info: err.message,
-        // Joi validation generates a list of readable messages, concat them here
-        validationErrors: err.errors && err.errors.length > 0 ?
-            err.errors.map(e => e.field.join('.') + ': ' + e.messages.join(', '))
-            : undefined
-    }).end();
-}
-
-function errorMiddleware(err, req, res, next) {
-    // ClientError was thrown
-    if (err instanceof ClientError) {
-        respondWithError(req, res, err);
-        return;
-    }
-
-    // Joi validation throws errors of type Error, with a status field set
-    if (err.status !== undefined) {
-        respondWithError(req, res, err);
-        return;
-    }
-
-    req.console.error(`Unhandled error: '${err.message}'`);
-    req.console.error(err);
-
-    respondWithError(req, res, new ClientError(500, 'Unhandled server error'));
-}
-
 async function createApp(middlewareOpts) {
     const app = express();
 
     await attachMiddlewares(app, middlewareOpts);
     attachHandlers(app);
 
-    // Add a generic error handler to take care of anything unhandled, and also
-    // any ClientErrors that are thrown by the handlers.
-    app.use(errorMiddleware);
+    attachErrorMiddlewares(app);
 
     return app;
 }

--- a/src/client-error.js
+++ b/src/client-error.js
@@ -17,14 +17,16 @@ limitations under the License.
 **/
 
 module.exports = class ClientError extends Error {
-    constructor(status, message) {
+    constructor(status, message, reason) {
         super(`Client error: ${message}`);
         this.status = status;
+        this.reason = reason;
     }
 
     toJSON() {
         return {
             info: this.message,
+            reason: this.reason,
         }
     }
 }

--- a/src/decrypt-body.js
+++ b/src/decrypt-body.js
@@ -42,14 +42,14 @@ class BodyDecryptor {
         try {
             decrypted = this._decryption.decrypt(ephemeral, mac, ciphertext);
         } catch (err) {
-            throw new ClientError(403, `Bad decryption: ${err.message}`);
+            throw new ClientError(403, `Bad decryption: ${err.message}`, 'MCS_BAD_DECRYPTION');
         }
 
         let result;
         try {
             result = JSON.parse(decrypted);
         } catch (err) {
-            throw new ClientError(400, `Malformed JSON: ${err.message}`);
+            throw new ClientError(400, `Malformed JSON: ${err.message}`, 'MCS_MALFORMED_JSON');
         }
 
         return result;

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -122,7 +122,7 @@ async function downloadHandler(req, res, next, matrixFile, thumbnailQueryParams)
     const cachedReport = await getReport(req.console, domain, mediaId, matrixFile, opts);
 
     if (cachedReport.scanned && !cachedReport.clean) {
-        throw new ClientError(403, cachedReport.info);
+        throw new ClientError(403, cachedReport.info, 'MCS_MEDIA_NOT_CLEAN');
     }
 
     const proxyDownloadWithTmpDir = withTempDir(tempDirectory, proxyDownload, getUnlinkFn(req.console));
@@ -145,7 +145,7 @@ async function proxyDownload(req, res, domain, mediaId, matrixFile, thumbnailQue
     } = await generateReportFromDownload(req.console, domain, mediaId, matrixFile, opts);
 
     if (!clean) {
-        throw new ClientError(403, info);
+        throw new ClientError(403, info, 'MCS_MEDIA_NOT_CLEAN');
     }
 
     req.console.info(`Sending ${filePath} to client`);

--- a/src/joi-error.js
+++ b/src/joi-error.js
@@ -16,15 +16,23 @@ limitations under the License.
 
 **/
 
-module.exports = class ClientError extends Error {
-    constructor(status, message) {
-        super(`Client error: ${message}`);
-        this.status = status;
+const ClientError = require('./client-error.js');
+
+module.exports = class JoiError extends ClientError {
+    constructor(err) {
+        super(err.status, err.message);
+        // Joi validation generates a list of readable messages, concat them here
+        if (err.errors && err.errors.length > 0) {
+            this._validationErrors = err.errors.map(
+                e => e.field.join('.') + ': ' + e.messages.join(', ')
+            )
+        }
     }
 
     toJSON() {
         return {
             info: this.message,
+            validationErrors: this._validationErrors,
         }
     }
 }

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -24,7 +24,7 @@ const JoiError = require('./joi-error.js');
 const attachEncryptedBodySubApp = require('./encrypted-body-sub-app.js');
 
 function jsonErrorMiddleware(err, req, res, next) {
-    next(new ClientError(400, `Malformed JSON: ${err.message}`));
+    next(new ClientError(400, `Malformed JSON: ${err.message}`, 'MCS_MALFORMED_JSON'));
 }
 
 async function attachMiddlewares(app, opts) {

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -212,7 +212,7 @@ async function _generateReportFromDownload(console, domain, mediaId, matrixFile,
 
         console.error(`Receieved status code ${err.statusCode} when requesting ${httpUrl}`);
 
-        throw new ClientError(502, 'Failed to get requested URL');
+        throw new ClientError(502, 'Failed to get requested URL', 'MCS_MEDIA_REQUEST_FAILED');
     }
 
     // Wait for the writable stream to close
@@ -269,7 +269,7 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
             decryptFile(filePath, decryptedFilePath, matrixFile);
         } catch (err) {
             console.error(err);
-            throw new ClientError(400, 'Failed to decrypt file');
+            throw new ClientError(400, 'Failed to decrypt file', 'MCS_MEDIA_FAILED_TO_DECRYPT');
         }
     }
 

--- a/test/middlewares-test.js
+++ b/test/middlewares-test.js
@@ -94,10 +94,10 @@ describe('middleware', () => {
             });
     });
 
-    it('sends a client error when one is thrown in a handler', async () => {
+    it('sends a client error with a reason when one is thrown in a handler', async () => {
         const app = await createMiddlewareApp((app) => {
             app.get('/error_endpoint', () => {
-                throw new ClientError(418, 'An error has occured');
+                throw new ClientError(418, 'An error has occured', 'MCS_I_AM_TEAPOT');
             });
         });
         return request(app)
@@ -105,6 +105,7 @@ describe('middleware', () => {
             .expect('Content-Type', /json/)
             .expect((res) => {
                 assert.strictEqual(res.status, 418, 'thrown client error status expected');
+                assert.strictEqual(res.body.reason, 'MCS_I_AM_TEAPOT', 'client error reason expected');
             });
     });
 

--- a/test/middlewares-test.js
+++ b/test/middlewares-test.js
@@ -1,0 +1,134 @@
+/**
+
+Copyright 2018 New Vector Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+**/
+
+const request = require('supertest');
+const assert = require('assert');
+const express = require('express');
+const validate = require('express-validation');
+const Joi = require('joi');
+const { PkEncryption } = require('olm');
+
+const { attachMiddlewares, attachErrorMiddlewares } = require('../src/middlewares.js');
+const ClientError = require('../src/client-error.js');
+
+async function createMiddlewareApp(attachHandlers) {
+    // Mock an express app because express doesn't expose an API to create request or
+    // response objects to give to the middlewares.
+    const app = express();
+
+    const middlewareOpts = {
+        // TODO: Test encrypted_body key pickling
+        encryptedBodyOpts: undefined,
+    };
+    await attachMiddlewares(app, middlewareOpts);
+
+    attachHandlers(app);
+
+    attachErrorMiddlewares(app);
+
+    return app;
+}
+
+describe('middleware', () => {
+    it('responds with 400 if Joi validation fails', async () => {
+        const endpointSchema = {
+            body: {
+                param_1: Joi.number().required(),
+            }
+        };
+        const app = await createMiddlewareApp(
+            (app) => app.post(
+                '/post_endpoint',
+                validate(endpointSchema),
+                (req, res) => res.status(200).json({}).end(),
+            )
+        );
+        return request(app)
+            .post('/post_endpoint')
+            .send({param_1: 'not a number'})
+            .expect('Content-Type', /json/)
+            .expect(400)
+            .then((res) => {
+                assert.strictEqual(res.body.validationErrors.length, 1, 'expected 1 validation error');
+            });
+    });
+
+    it('responds with 400 when JSON is malformed', async () => {
+        const app = await createMiddlewareApp(
+            (app) => app.post('/post_endpoint', (req, res) => res.status(200).json({}).end())
+        );
+        return request(app)
+            .post('/post_endpoint')
+            .type('application/json')
+            .send('this is malformed {} json')
+            .expect('Content-Type', /json/)
+            .expect(400);
+    });
+
+    it('reports internal server error when a handler throws a generic error', async () => {
+        const app = await createMiddlewareApp((app) => {
+            app.get('/error_endpoint', () => {
+                throw new Error('An error has occured');
+            });
+        });
+        return request(app)
+            .get('/error_endpoint')
+            .expect('Content-Type', /json/)
+            .expect((res) => {
+                assert.strictEqual(res.status, 500, 'server error status expected');
+            });
+    });
+
+    it('sends a client error when one is thrown in a handler', async () => {
+        const app = await createMiddlewareApp((app) => {
+            app.get('/error_endpoint', () => {
+                throw new ClientError(418, 'An error has occured');
+            });
+        });
+        return request(app)
+            .get('/error_endpoint')
+            .expect('Content-Type', /json/)
+            .expect((res) => {
+                assert.strictEqual(res.status, 418, 'thrown client error status expected');
+            });
+    });
+
+    it('proxies an encrypted_body POST request through to a unencrypted request handler', async () => {
+        const app = await createMiddlewareApp((app) => {
+            app.post('/post_endpoint', (req, res) => {
+                res.status(req.body.some === 'body' ? 200 : 406).end();
+            });
+        });
+
+        const plainBody = { some: 'body' };
+
+        const publicKey = await request(app)
+            .get('/_matrix/media_proxy/unstable/public_key')
+            .then(response => response.body.public_key);
+
+        const encryption = new PkEncryption();
+        encryption.set_recipient_key(publicKey);
+
+        const encryptedBody = encryption.encrypt(JSON.stringify(plainBody));
+
+        return request(app)
+            .post('/post_endpoint')
+            .send({encrypted_body: encryptedBody})
+            .expect(200);
+    });
+});


### PR DESCRIPTION
For example, clients can now distinguish between `MCS_BAD_DECRYPTION` and `MCS_MEDIA_NOT_CLEAN` (which are both error code 403).