### PR TITLE
Make a copy of unencrypted files before scanning

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -258,11 +258,10 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
         return reportCache[reportHash];
     }
 
-    // By default, the file is considered decrypted
-    let decryptedFilePath = filePath;
+    // Always make a decryptedFile on disk
+    let decryptedFilePath = path.join(tempDir, 'unsafeDownloadedDecryptedFile');
 
     if (matrixFile && matrixFile.key) {
-        decryptedFilePath = path.join(tempDir, 'unsafeDownloadedDecryptedFile');
         console.info(`Decrypting ${filePath}, writing to ${decryptedFilePath}`);
 
         try {
@@ -270,6 +269,13 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
         } catch (err) {
             console.error(err);
             throw new ClientError(400, 'Failed to decrypt file', 'MCS_MEDIA_FAILED_TO_DECRYPT');
+        }
+    } else {
+        try {
+            fs.copyFileSync(filePath, decryptedFilePath);
+        } catch (err) {
+            console.error(err);
+            throw new ClientError(400, 'Failed to copy file for decryption', 'MCS_MEDIA_FAILED_TO_DECRYPT');
         }
     }
 


### PR DESCRIPTION
If decryption is not required, copy the file anyway so the logic
around removing the "decrypted" version as soon as possible will still function.

This allows us to serve the file we recieved from the media_repo back to the client, even if
that file was originally undecrypted.

Taking this approach means we do not need an if block to handle the two cases of decrypted and encrypted source files, which makes this easier to reason about.

I believe this fixes #30