### PR TITLE
Fixing a bug where the file is not copied for analyse if the acceptedMimeType option is not present

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -293,12 +293,12 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
                 console.info(`FileType: ${type.mime}`);
                 return {clean: false, info: 'File type not supported'};
             }
-            try {
-                fs.copyFileSync(filePath, decryptedFilePath);
-            } catch (err) {
-                console.error(err);
-                throw new ClientError(400, 'Failed to copy file for decryption', 'MCS_MEDIA_FAILED_TO_DECRYPT');
-            }
+        }
+        try {
+            fs.copyFileSync(filePath, decryptedFilePath);
+        } catch (err) {
+            console.error(err);
+            throw new ClientError(400, 'Failed to copy file for decryption', 'MCS_MEDIA_FAILED_TO_DECRYPT');
         }
     }
 


### PR DESCRIPTION
If the acceptedMimeType option is not present on the configuration file, the MCS will not copy the file in the tmp directory for the analyse.
This commit will correct this.

Signed-off-by: Léo Mora [l.mora@outlook.fr](l.mora@outlook.fr)