### PR TITLE
Fix unit tests

### DIFF
--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -74,7 +74,7 @@ describe('handlers', () => {
                 scan: {
                 baseUrl: "https://matrix.org",
                     tempDirectory: "/tmp",
-                    script: "exit 0"
+                    script: "exit 0 #"
                 },
                 altRemovalCmd: 'rm',
                 acceptedMimeType: ['image/jpg']

--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -32,7 +32,7 @@ describe('handlers', () => {
             scan: {
                 baseUrl: "https://matrix.org",
                 tempDirectory: "/tmp",
-                script: "exit 0 #"
+                script: "true"
             },
             altRemovalCmd: 'rm'
         });
@@ -74,7 +74,7 @@ describe('handlers', () => {
                 scan: {
                 baseUrl: "https://matrix.org",
                     tempDirectory: "/tmp",
-                    script: "exit 0 #"
+                    script: "true"
                 },
                 altRemovalCmd: 'rm',
                 acceptedMimeType: ['image/jpg']
@@ -94,7 +94,7 @@ describe('handlers', () => {
                 scan: {
                     baseUrl: "https://matrix.org",
                     tempDirectory: "/tmp",
-                    script: "exit 0 #"
+                    script: "true"
                 },
                 altRemovalCmd: 'rm',
                 acceptedMimeType: ['image/png']

--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -32,7 +32,7 @@ describe('handlers', () => {
             scan: {
                 baseUrl: "https://matrix.org",
                 tempDirectory: "/tmp",
-                script: "exit 0"
+                script: "exit 0 #"
             },
             altRemovalCmd: 'rm'
         });
@@ -94,7 +94,7 @@ describe('handlers', () => {
                 scan: {
                     baseUrl: "https://matrix.org",
                     tempDirectory: "/tmp",
-                    script: "exit 0"
+                    script: "exit 0 #"
                 },
                 altRemovalCmd: 'rm',
                 acceptedMimeType: ['image/png']

--- a/test/reporting-test.js
+++ b/test/reporting-test.js
@@ -28,7 +28,7 @@ const assert = require('assert');
 const generateConfig = {
     baseUrl: "https://matrix.org",
     tempDirectory: "/tmp",
-    script: "exit 0 #"
+    script: "true"
 };
 
 const example = require('../example.file.json');
@@ -114,7 +114,7 @@ describe('reporting.js', () => {
                 tempDirectory: "/tmp",
 
                 // Script that will always mark a file as unsafe
-                script: "exit 1 #",
+                script: "false",
             };
             const report = await generateDecryptedReportFromFile(modifiedConfig);
 

--- a/test/reporting-test.js
+++ b/test/reporting-test.js
@@ -28,7 +28,7 @@ const assert = require('assert');
 const generateConfig = {
     baseUrl: "https://matrix.org",
     tempDirectory: "/tmp",
-    script: "exit 0"
+    script: "exit 0 #"
 };
 
 const example = require('../example.file.json');
@@ -114,7 +114,7 @@ describe('reporting.js', () => {
                 tempDirectory: "/tmp",
 
                 // Script that will always mark a file as unsafe
-                script: "exit 1",
+                script: "exit 1 #",
             };
             const report = await generateDecryptedReportFromFile(modifiedConfig);
 


### PR DESCRIPTION
The CI was failing when the script is 'exit X' because the content scanner tries to invoke it with the file to scan as its last parameter.
This fixes it by adding the character '#' to the script passed through the config in these cases, so that any further parameter is considered a comment and isn't interpreted by bash.