### PR TITLE
Multi-stage Dockerfile for a smaller build & update to Node 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 config
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM node:14
+FROM node:14 AS builder
 
 WORKDIR /usr/src/app
-
-RUN apt-get update && apt-get install -y vim secure-delete && apt-get clean
 
 COPY package*.json ./
 
 RUN npm install
 
-COPY . .
+FROM node:14-alpine
+
+WORKDIR /usr/src/app
+
+COPY config config
+COPY example* ./
+COPY package.json .
+COPY src src
+COPY test test
+COPY --from=builder /usr/src/app/node_modules node_modules
 
 EXPOSE 8080
 
 CMD [ "npm", "start", "--", "config/docker.config.yaml" ]
-


### PR DESCRIPTION
Drops the image size from 1GB to 129MB. Does not include vim or secure-delete - are these actually needed in a production deployment?

Test pass on Node 14 which is the current LTS.