### PR TITLE
Update olm to v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Retrieving scan results follows the same steps but exposes a different API, as e
 
 # Dependencies
 ### Olm
-MCS requires the Olm library to handle `encrypted_body` requests. The version of Olm required is >2.2.2 and exposes the `PkEncryption` class. See [https://git.matrix.org/git/olm/](https://git.matrix.org/git/olm/).
+MCS requires the Olm library to handle `encrypted_body` requests. The version of Olm required is >3.2.3 and exposes the `PkEncryption` class. See [https://git.matrix.org/git/olm/](https://git.matrix.org/git/olm/).
 
 # Configuration
 See the [default configuration](config/default.config.yaml) for details.

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
     "start": "node src/index.js"
   },
   "dependencies": {
+    "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "cors": "^2.8.4",
     "express": "^4.16.3",
     "express-validation": "^1.0.2",
     "file-type": "^10.5.0",
     "joi": "^13.3.0",
     "js-yaml": "^3.12.0",
-    "olm": "https://matrix.org/packages/npm/olm/olm-2.3.0.tgz",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",
     "rimraf": "^2.6.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "supertest": "^3.1.0"
+    "supertest": "^3.4.2"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,6 @@ limitations under the License.
 
 const express = require('express');
 
-const ClientError = require('./client-error.js');
 const { attachMiddlewares, attachErrorMiddlewares } = require('./middlewares.js');
 const { attachHandlers } = require('./handlers.js');
 
@@ -29,6 +28,17 @@ const path = require('path');
 
 async function createApp(middlewareOpts) {
     const app = express();
+
+    // Load and initialise olm
+    console.debug("Initialising Olm lib...")
+    try {
+        // Store Olm under the global namespace as we'll need to use it elsewhere
+        global.Olm = require('@matrix-org/olm');
+        await global.Olm.init();
+    } catch (err) {
+        console.error("Failed to initialise olm library")
+        process.exit(1)
+    }
 
     await attachMiddlewares(app, middlewareOpts);
     attachHandlers(app);

--- a/src/decrypt-body.js
+++ b/src/decrypt-body.js
@@ -16,12 +16,12 @@ limitations under the License.
 
 **/
 
-const { PkDecryption } = require('olm');
+const { PkDecryption } = require('@matrix-org/olm');
 const ClientError = require('../src/client-error.js');
 
 class BodyDecryptor {
     constructor(pickleKey, pickle) {
-        this._decryption = new PkDecryption();
+        this._decryption = PkDecryption();
         this._pickleKey = pickleKey;
 
         if (pickleKey && pickle) {

--- a/src/decrypt-body.js
+++ b/src/decrypt-body.js
@@ -16,12 +16,11 @@ limitations under the License.
 
 **/
 
-const { PkDecryption } = require('@matrix-org/olm');
 const ClientError = require('../src/client-error.js');
 
 class BodyDecryptor {
     constructor(pickleKey, pickle) {
-        this._decryption = PkDecryption();
+        this._decryption = new global.Olm.PkDecryption();
         this._pickleKey = pickleKey;
 
         if (pickleKey && pickle) {

--- a/test/decrypt-body-test.js
+++ b/test/decrypt-body-test.js
@@ -17,7 +17,7 @@ limitations under the License.
 **/
 
 const assert = require('assert');
-const { PkEncryption } = require('olm');
+const { PkEncryption } = require('@matrix-org/olm');
 const BodyDecryptor = require('../src/decrypt-body.js');
 const ClientError = require('../src/client-error.js');
 

--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -27,6 +27,17 @@ const example = require('../example.file.json');
 const { setConfig } = require('../src/config.js');
 
 describe('handlers', () => {
+    before("Initialise Olm library", async () => {
+        try {
+            // Store Olm under the global namespace as we'll need to use it elsewhere
+            global.Olm = require('@matrix-org/olm');
+            await global.Olm.init();
+        } catch (err) {
+            console.error("Failed to initialise olm library")
+            process.exit(1)
+        }
+    });
+
     beforeEach(() => {
         setConfig({
             scan: {
@@ -147,7 +158,7 @@ describe('handlers', () => {
                 .get('/_matrix/media_proxy/unstable/public_key')
                 .then(response => response.body.public_key);
 
-            const encryption = new PkEncryption();
+            const encryption = new global.Olm.PkEncryption();
             encryption.set_recipient_key(publicKey);
             const encryptedBody = encryption.encrypt(JSON.stringify(plainBody));
 

--- a/test/handlers-test.js
+++ b/test/handlers-test.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 const request = require('supertest');
 const assert = require('assert');
-const { PkEncryption } = require('olm');
+const { PkEncryption } = require('@matrix-org/olm');
 
 const { createApp } = require('../src/app.js');
 const { clearReportCache } = require('../src/reporting.js');

--- a/test/middlewares-test.js
+++ b/test/middlewares-test.js
@@ -45,6 +45,17 @@ async function createMiddlewareApp(attachHandlers) {
 }
 
 describe('middleware', () => {
+    before("Initialise Olm library", async () => {
+        try {
+            // Store Olm under the global namespace as we'll need to use it elsewhere
+            global.Olm = require('@matrix-org/olm');
+            await global.Olm.init();
+        } catch (err) {
+            console.error("Failed to initialise olm library")
+            process.exit(1)
+        }
+    });
+
     it('responds with 400 if Joi validation fails', async () => {
         const endpointSchema = {
             body: {
@@ -122,7 +133,7 @@ describe('middleware', () => {
             .get('/_matrix/media_proxy/unstable/public_key')
             .then(response => response.body.public_key);
 
-        const encryption = new PkEncryption();
+        const encryption = new global.Olm.PkEncryption();
         encryption.set_recipient_key(publicKey);
 
         const encryptedBody = encryption.encrypt(JSON.stringify(plainBody));

--- a/test/middlewares-test.js
+++ b/test/middlewares-test.js
@@ -21,7 +21,7 @@ const assert = require('assert');
 const express = require('express');
 const validate = require('express-validation');
 const Joi = require('joi');
-const { PkEncryption } = require('olm');
+const { PkEncryption } = require('@matrix-org/olm');
 
 const { attachMiddlewares, attachErrorMiddlewares } = require('../src/middlewares.js');
 const ClientError = require('../src/client-error.js');


### PR DESCRIPTION
We were using Olm v2 still. This PR updates the dependency of Olm to the latest version (v3.2.3).

As this is bumping a major version of Olm, there was a breaking change. Namely that the [olm library must now be initialised](https://gitlab.matrix.org/matrix-org/olm/-/blob/master/CHANGELOG.rst). I opted to do so in `createApp`, and assigned the initialised `Olm` object to NodeJS's `global` object, which is accessible across the current process.

The tests were a bit messier. I couldn't easily figure out a nice place to initialise Olm once for all tests. So instead, we initialise in each test file where necessary.