### PR TITLE
Switch back to Debian based docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN npm install
 
 FROM node:14-slim
 
+# `secure-delete` adds the `srm` utility to securely delete files.
+# This is a better alternative to Node's `unlink`. The default config in
+# `docker/docker.config.yaml` is already configured to use `srm` as the
+# utility to delete the scanned files, which is why we add it to the base image.
 RUN apt-get update && apt-get install -y secure-delete && apt-get clean
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY package*.json ./
 
 RUN npm install
 
-FROM node:14-alpine
+FROM node:14-slim
+
+RUN apt-get update && apt-get install -y secure-delete && apt-get clean
 
 WORKDIR /usr/src/app
 

--- a/config/docker.config.yaml
+++ b/config/docker.config.yaml
@@ -24,5 +24,7 @@ scan:
 # system instead of using node's fs.unlink. When executed, the first
 # argument to the command will be the path of the file being
 # removed.
+# Docker note: the `srm` utility is already bundled into the base Docker image
+# built by the project. See `Dockerfile` for additional notes.
 #
 altRemovalCmd: 'srm'


### PR DESCRIPTION
The switch to Alpine in #40 proved problematic in some custom stuff that we needed in EMS land. The Debian base is more versatile to build on.

This also allows using `secure-delete` to remove temporary files which was also difficult to pull into Alpine.