### PR TITLE
Fixes for decrypted file mimetype checks

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -335,8 +335,8 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
             if (mimetype === null) {
                 console.info(`Skipping unsupported decrypted file - unknown mimetype`);
                 return {clean: false, info: 'File type not supported'};
-            } else if (!mimetypeArray.includes(mimetype)) {
-                console.info(`Skipping unsupported decrypted file ${mimetype}`);
+            } else if (!mimetypeArray.includes(mimetype.mime)) {
+                console.info(`Skipping unsupported decrypted file ${mimetype.mime}`);
                 return {clean: false, info: 'File type not supported'};
             }
         }

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -313,7 +313,7 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
 
     if (matrixFile && matrixFile.key) {
         console.info(`Decrypting ${filePath}, writing to ${decryptedFilePath}`);
-        console.info(`FileType: ${matrixFile.mimetype}`);
+        console.info(`FileType: ${matrixFile.mimetype} [${filePath}]`);
 
         // Do an initial check of the mimetype based on what is reported by the client
         if (mimetypeArray && !mimetypeArray.includes(matrixFile.mimetype)) {
@@ -333,10 +333,10 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
         if (mimetypeArray) {
             const mimetype = fileType(decryptedFileContents);
             if (mimetype === null) {
-                console.info(`Skipping unsupported decrypted file - unknown mimetype`);
+                console.info(`Skipping unsupported decrypted file - unknown mimetype [${filePath}]`);
                 return {clean: false, info: 'File type not supported'};
             } else if (!mimetypeArray.includes(mimetype.mime)) {
-                console.info(`Skipping unsupported decrypted file ${mimetype.mime}`);
+                console.info(`Skipping unsupported decrypted file ${mimetype.mime} [${filePath}]`);
                 return {clean: false, info: 'File type not supported'};
             }
         }
@@ -353,10 +353,10 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
             const fileData = fs.readFileSync(filePath);
             const mimetype = fileType(fileData);
             if (mimetype === null) {
-                console.info(`Skipping unsupported file - unknown mimetype`);
+                console.info(`Skipping unsupported file - unknown mimetype [${filePath}]`);
                 return {clean: false, info: 'File type not supported'};
             } else if (!mimetypeArray.includes(mimetype.mime)) {
-                console.info(`Skipping unsupported file type ${mimetype.mime}`);
+                console.info(`Skipping unsupported file type ${mimetype.mime} [${filePath}]`);
                 return {clean: false, info: 'File type not supported'};
             }
         }

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -330,11 +330,15 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
         }
 
         // Further validate the mimetype of the file from the decrypted content
-        let mimetype = fileType(decryptedFileContents);
-        if (mimetype === null) {
-            return {clean: false, info: 'File type not supported'};
-        } else if (mimetypeArray && !mimetypeArray.includes(mimetype)) {
-            return {clean: false, info: 'File type not supported'};
+        if (mimetypeArray) {
+            const mimetype = fileType(decryptedFileContents);
+            if (mimetype === null) {
+                console.info(`Skipping unsupported decrypted file - unknown mimetype`);
+                return {clean: false, info: 'File type not supported'};
+            } else if (!mimetypeArray.includes(mimetype)) {
+                console.info(`Skipping unsupported decrypted file ${mimetype}`);
+                return {clean: false, info: 'File type not supported'};
+            }
         }
 
         // Write the decrypted file bytes to disk
@@ -345,13 +349,14 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
             throw new ClientError(400, 'Failed to write decrypted file to disk', 'MCS_MEDIA_FAILED_TO_DECRYPT');
         }
     } else {
-        let fileData = fs.readFileSync(filePath);
-        let mimetype = fileType(fileData);
         if (mimetypeArray) {
+            const fileData = fs.readFileSync(filePath);
+            const mimetype = fileType(fileData);
             if (mimetype === null) {
+                console.info(`Skipping unsupported file - unknown mimetype`);
                 return {clean: false, info: 'File type not supported'};
-            } else if (mimetypeArray && !mimetypeArray.includes(mimetype.mime)) {
-                console.info(`FileType: ${mimetype.mime}`);
+            } else if (!mimetypeArray.includes(mimetype.mime)) {
+                console.info(`Skipping unsupported file type ${mimetype.mime}`);
                 return {clean: false, info: 'File type not supported'};
             }
         }


### PR DESCRIPTION
*  Fix decrypted file mimetype checks
  
   The decrypted path only fails the file on unknown mimetype if we're actually configured with a list of mimetypes. Add the missing `if` to look at that config.

   Also add a bit of logging when files are skipped due to mimetype and make some let's const, since we don't redeclare them.

* Fix checking of mimetype for decrypted files
  
  The "includes" check was being made against `mimetype` which is an object, when it should be made against `mimetype.mime`.



