### PR TITLE
Don't check the mimetype via content.file.mimetype

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -313,12 +313,6 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
 
     if (matrixFile && matrixFile.key) {
         console.info(`Decrypting ${filePath}, writing to ${decryptedFilePath}`);
-        console.info(`FileType: ${matrixFile.mimetype} [${filePath}]`);
-
-        // Do an initial check of the mimetype based on what is reported by the client
-        if (mimetypeArray && !mimetypeArray.includes(matrixFile.mimetype)) {
-            return {clean: false, info: 'File type not supported'};
-        }
 
         // Decrypt the file
         let decryptedFileContents;


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-content-scanner/issues/50.

This field is not actually specced. The specced field is at content.info.mimetype, which [isn't currently sent to the content scanner](https://github.com/matrix-org/matrix-content-scanner#post-download_encrypted).

We check the mimetype of the file by scanning the file itself. As issue #49 mentions, this check is not infallible, but that should be fixed separately.