### PR TITLE
Allow defining error codes ignored by the cache

### DIFF
--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -6,6 +6,13 @@ server:
 scan:
     # The script that will be given a file as its first parameter
     script: './example.sh'
+    # If set and the script exits with an exit code listed here, the failure will not be
+    # cached. Useful to prevent caching of a failure due to e.g. the antivirus restarting.
+    #
+    # doNotCacheExitCodes:
+    #   - 1
+    #   - 2
+    #
     # The temporary directory to use
     tempDirectory: '/tmp'
     # The base URL of the homeserver to download media from

--- a/config/docker.config.yaml
+++ b/config/docker.config.yaml
@@ -6,6 +6,13 @@ server:
 scan:
     # The script that will be given a file as its first parameter
     script: './example.sh'
+    # If set and the script exits with an exit code listed here, the failure will not be
+    # cached. Useful to prevent caching of a failure due to e.g. the antivirus restarting.
+    #
+    # doNotCacheExitCodes:
+    #   - 1
+    #   - 2
+    #
     # The temporary directory to use
     tempDirectory: '/tmp'
     # The base URL of the homeserver to download media from

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,7 @@ const configSchema = Joi.object().keys({
     }).required(),
     scan: Joi.object().keys({
         script: Joi.string().required(),
+        doNotCacheExitCodes: Joi.array().items(Joi.number()),
         tempDirectory: Joi.string().required(),
         baseUrl: Joi.string().required(),
         directDownload: Joi.boolean(),

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -366,7 +366,14 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
     console.info(`Running command ${cmd}`);
     const result = await executeCommand(cmd);
 
-    reportCache[reportHash] = result;
+    const config = getConfig();
+
+    if (
+        !config.scan.doNotCacheExitCodes
+        || !(result.exitCode in config.scan.doNotCacheExitCodes)
+    ) {
+        reportCache[reportHash] = result;
+    }
 
     return result;
 }

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -368,8 +368,10 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
 
     const config = getConfig();
 
+    // Only cache the result if the config doesn't tell us otherwise (i.e. only if
+    // doNotCacheExitCodes is an array that contains the exit code).
     if (
-        !config.scan.doNotCacheExitCodes
+        !Array.isArray(config.scan.doNotCacheExitCodes)
         || !config.scan.doNotCacheExitCodes.includes(result.exitCode)
     ) {
         reportCache[reportHash] = result;

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -370,7 +370,7 @@ async function generateReport(console, httpUrl, matrixFile, filePath, tempDir, s
 
     if (
         !config.scan.doNotCacheExitCodes
-        || !(result.exitCode in config.scan.doNotCacheExitCodes)
+        || !config.scan.doNotCacheExitCodes.includes(result.exitCode)
     ) {
         reportCache[reportHash] = result;
     }

--- a/test/reporting-test.js
+++ b/test/reporting-test.js
@@ -144,5 +144,36 @@ describe('reporting.js', () => {
 
             assert.strictEqual(report.clean, false);
         });
+
+        it('should not cache if a scan failed with an exit code that should be ignored', async () => {
+            setConfig({
+                scan: {
+                    baseUrl: "https://matrix.org",
+                    tempDirectory: "/tmp",
+                    script: "true",
+                    doNotCacheExitCodes: [5]
+                },
+                altRemovalCmd: 'rm',
+            })
+
+            const failureReport = await generateDecryptedReportFromFile({
+                baseUrl: "https://matrix.org",
+                tempDirectory: "/tmp",
+                // Script that exits with the error code we want to ignore, and ignores
+                // any other argument.
+                script: "exit 5;",
+            });
+
+            assert.strictEqual(failureReport.clean, false)
+
+            const successReport = await generateDecryptedReportFromFile({
+                baseUrl: "https://matrix.org",
+                tempDirectory: "/tmp",
+                // Now we want to accept everything.
+                script: "true",
+            });
+
+            assert.strictEqual(successReport.clean, true)
+        });
     });
 });

--- a/test/reporting-test.js
+++ b/test/reporting-test.js
@@ -22,6 +22,7 @@ const {
     generateHttpUrl,
     clearReportCache,
 } = require('../src/reporting.js');
+const {setConfig} = require("../src/config.js");
 
 const assert = require('assert');
 
@@ -58,6 +59,15 @@ function generateDecryptedReportFromFile(config = generateConfig) {
 describe('reporting.js', () => {
     beforeEach(() => {
         clearReportCache();
+
+        setConfig({
+            scan: {
+                baseUrl: "https://matrix.org",
+                tempDirectory: "/tmp",
+                script: "true"
+            },
+            altRemovalCmd: 'rm',
+        });
     });
 
     describe('getReport', () => {

--- a/test/reporting-test.js
+++ b/test/reporting-test.js
@@ -175,5 +175,26 @@ describe('reporting.js', () => {
 
             assert.strictEqual(successReport.clean, true)
         });
+
+        it('should cache a scan result', async () => {
+            const firstReport = await generateDecryptedReportFromFile({
+                baseUrl: "https://matrix.org",
+                tempDirectory: "/tmp",
+                // Mark every file as unsafe to see if the file is still cached as unsafe
+                // after we change the script to accept it.
+                script: "false",
+            });
+
+            assert.strictEqual(firstReport.clean, false)
+
+            const secondReport = await generateDecryptedReportFromFile({
+                baseUrl: "https://matrix.org",
+                tempDirectory: "/tmp",
+                // Now we want to accept everything.
+                script: "true",
+            });
+
+            assert.strictEqual(secondReport.clean, false)
+        });
     });
 });


### PR DESCRIPTION
This is to avoid caching an accidental failure due to the AV being down (e.g. restarting etc).

Will require https://github.com/matrix-org/matrix-dinsic/pull/829 to be merged and deployed before being usable on DINUM's infra.

Fixes #56