### PR TITLE
Return after handling an error when getting a file

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -257,7 +257,7 @@ async function _generateReportFromDownload(req, domain, mediaId, matrixFile, opt
                 resolve(res.headers);
             });
         }).catch(err => {
-            console.error(`Failed to download file: ${err.message}`)
+            console.error(`Failed to download file: ${err.message}`);
             throw new ClientError(502, 'Failed to get requested URL', 'MCS_MEDIA_REQUEST_FAILED');
         });
     } catch (err) {

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -245,7 +245,10 @@ async function _generateReportFromDownload(req, domain, mediaId, matrixFile, opt
 
             // Download the media
             get(opts, (err, res) => {
-                if (err) reject(err);
+                if (err) {
+                    reject(err);
+                    return;
+                }
 
                 // Write the file
                 res.pipe(fileWriteStream);
@@ -253,6 +256,9 @@ async function _generateReportFromDownload(req, domain, mediaId, matrixFile, opt
                 // Save the response headers
                 resolve(res.headers);
             });
+        }).catch(err => {
+            console.error(`Failed to download file: ${err.message}`)
+            throw new ClientError(502, 'Failed to get requested URL', 'MCS_MEDIA_REQUEST_FAILED');
         });
     } catch (err) {
         if (!err.statusCode) {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-content-scanner/issues/55

It looks like the code assumes `reject` returns after handling an error, which doesn't seem to be the case in javascript.
Also improve the error handling a bit so the client doesn't get `Unhandled server error`.

Introduced in https://github.com/matrix-org/matrix-content-scanner/pull/47