### PR TITLE
Add warning about MIME type sniffing and security

### DIFF
--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -67,12 +67,15 @@ middleware:
         picklePath: 'av_pickled_decryption.key'
 
 # Optional. A list of accepted MIME types.
-# WARNING! It should be noted that this cannot be relied on for security:
-# it is possible to specially craft files that look like different kinds of file.
-# As one example, it is possible to craft a file which is both a PNG file and a
+#
+# WARNING! This cannot be relied on for security:
+#
+# it is possible to specially craft a file that looks like a different kind of file.
+# As one example, it is possible for a file to be both a PNG file and a
 # ZIP file yet will be detected as `image/png`.
 # Further, it should be generally assumed that most file formats have a way to
 # encode and attach extraneous data.
+#
 #acceptedMimeType:
 #    - 'image/jpeg'
 #    - 'image/jpg'

--- a/config/default.config.yaml
+++ b/config/default.config.yaml
@@ -66,7 +66,13 @@ middleware:
         # requests.
         picklePath: 'av_pickled_decryption.key'
 
-# Optional. A list of accepted mime type.
+# Optional. A list of accepted MIME types.
+# WARNING! It should be noted that this cannot be relied on for security:
+# it is possible to specially craft files that look like different kinds of file.
+# As one example, it is possible to craft a file which is both a PNG file and a
+# ZIP file yet will be detected as `image/png`.
+# Further, it should be generally assumed that most file formats have a way to
+# encode and attach extraneous data.
 #acceptedMimeType:
 #    - 'image/jpeg'
 #    - 'image/jpg'


### PR DESCRIPTION
Thought it was worth explicitly pointing this out. The content scanner doesn't make any effort to scrub the files or anything (this might be doable as an external script but it's not built in and you ought not to rely on it too much!)